### PR TITLE
Return the original failure/error content of a test case

### DIFF
--- a/src/main/proto/test_suite.proto
+++ b/src/main/proto/test_suite.proto
@@ -79,7 +79,9 @@ message StackTrace {
     optional string exception_type = 2;
     repeated Property unrecognized_attributes = 3;
 
+    // Experimental, sometimes the stack trace parsing might not work.
     repeated StackContent stack_content = 4;
+    optional string content = 5;
 }
 
 // In Ant's junit task XML format, this message represents a line within a <failure> such as

--- a/src/test/java/com/google/testing/results/AntXmlParserTest.java
+++ b/src/test/java/com/google/testing/results/AntXmlParserTest.java
@@ -147,6 +147,14 @@ public class AntXmlParserTest {
             .addFailure(StackTrace.newBuilder()
                 .setExceptionMessage("expected:<1> but was:<2>")
                 .setExceptionType("java.lang.AssertionError")
+                .setContent("java.lang.AssertionError: expected:<1> but was:<2>\n"
+                    + "\tat org.junit.Assert.fail(Assert.java:88)\n"
+                    + "\tat org.junit.Assert.failNotEquals(Assert.java:743)\n"
+                    + "\tat org.junit.Assert.assertEquals(Assert.java:118)\n"
+                    + "\tat org.junit.Assert.assertEquals(Assert.java:555)\n"
+                    + "\tat org.junit.Assert.assertEquals(Assert.java:542)\n"
+                    + "\tat com.google.SimpleTest.testThatFails(SimpleTest.java:11)\n"
+                    + "\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n")
                 .addStackContent(text(
                     "java.lang.AssertionError: expected:<1> but was:<2>\n"
                         + "\tat org.junit.Assert.fail("))
@@ -201,6 +209,13 @@ public class AntXmlParserTest {
             .setError(StackTrace.newBuilder()
                 .setExceptionMessage("/ by zero")
                 .setExceptionType("java.lang.ArithmeticException")
+                .setContent("java.lang.ArithmeticException: / by zero\n"
+                    + "\tat com.google.ExceptionThrownTest.testDivision(ExceptionThrownTest.java:11)\n"
+                    + "\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n"
+                    + "\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)\n"
+                    + "\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n"
+                    + "\tat java.lang.reflect.Method.invoke(Method.java:606)\n"
+                    + "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)\n")
                 .addStackContent(text("java.lang.ArithmeticException: / by zero\n"
                     + "\tat com.google.ExceptionThrownTest.testDivision("))
                 .addStackContent(codeRef(
@@ -238,6 +253,15 @@ public class AntXmlParserTest {
     StackTrace.Builder expectedError = StackTrace.newBuilder()
         .setExceptionMessage("Division operation failed")
         .setExceptionType("java.lang.RuntimeException")
+        .setContent("java.lang.RuntimeException: Division operation failed\n"
+            + "\tat com.google.NestedExceptionThrownTest.testDivision(NestedExceptionThrownTest.java:14)\n"
+            + "\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n"
+            + "\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)\n"
+            + "\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n"
+            + "\tat java.lang.reflect.Method.invoke(Method.java:606)\n"
+            + "Caused by: java.lang.ArithmeticException: / by zero\n"
+            + "\tat com.google.NestedExceptionThrownTest.testDivision(NestedExceptionThrownTest.java:12)\n"
+            + "\t... 4 more\n")
         .addStackContent(text("java.lang.RuntimeException: Division operation failed\n"
             + "\tat com.google.NestedExceptionThrownTest.testDivision("))
         .addStackContent(codeRef(
@@ -295,6 +319,22 @@ public class AntXmlParserTest {
             + "\n"
             + "2 errors").replaceAll("\n", " "))
         .setExceptionType("com.google.inject.CreationException")
+        .setContent("com.google.inject.CreationException: Guice creation errors:\n"
+            + "\n"
+            + "1) No implementation for java.lang.Integer annotated with @com.google.GuiceExceptionTest$A() was bound.\n"
+            + "  at com.google.GuiceExceptionTest$MyModule.provideA(GuiceExceptionTest.java:44)\n"
+            + "\n"
+            + "2) No implementation for java.lang.Integer annotated with @com.google.GuiceExceptionTest$B() was bound.\n"
+            + "  at com.google.GuiceExceptionTest$MyModule.provideB(GuiceExceptionTest.java:49)\n"
+            + "\n"
+            + "2 errors\n"
+            + "\tat com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:435)\n"
+            + "\tat com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:154)\n"
+            + "\tat com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:106)\n"
+            + "\tat com.google.inject.Guice.createInjector(Guice.java:95)\n"
+            + "\tat com.google.inject.Guice.createInjector(Guice.java:72)\n"
+            + "\tat com.google.inject.Guice.createInjector(Guice.java:62)\n"
+            + "\tat com.google.GuiceExceptionTest.testGuiceException(GuiceExceptionTest.java:21)")
         .addStackContent(text("com.google.inject.CreationException: Guice creation errors:\n"
             + "\n"
             + "1) No implementation for java.lang.Integer annotated with @com.google.GuiceExceptionTest$A() was bound.\n"
@@ -370,6 +410,9 @@ public class AntXmlParserTest {
             .setError(StackTrace.newBuilder()
                 .setExceptionMessage("/ by zero")
                 .setExceptionType("java.lang.ArithmeticException")
+                .setContent("java.lang.ArithmeticException: / by zero\n"
+                    + "\tat java.lang.reflect.Method.invoke\n"
+                    + "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)\n")
                 .addStackContent(text("java.lang.ArithmeticException: / by zero\n"
                     + "\tat java.lang.reflect.Method.invoke\n"
                     + "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall("))
@@ -422,8 +465,17 @@ public class AntXmlParserTest {
   }
 
   @Test
+  public void shouldRaiseXmlParseErrorWhenTestSuiteContainsTestSuite() throws Exception {
+    thrown.expect(XmlParseException.class);
+    thrown.expectMessage("Element <testsuite> should not contain element <testsuite>.");
+    parser.parse(
+        getClass().getResourceAsStream("/unsupported_testsuite_element.xml"), UTF_8);
+  }
+
+  @Test
   public void shouldRaiseXmlParseErrorWithMalformedXMLInput() throws Exception {
     thrown.expect(XmlParseException.class);
+    thrown.expectMessage("Element <root> should not contain element <one>.");
     parser.parse(
         getClass().getResourceAsStream("/malformed-xml.xml"), UTF_8);
   }

--- a/src/test/resources/unsupported_testsuite_element.xml
+++ b/src/test/resources/unsupported_testsuite_element.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2015 Google Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<testsuites name="" tests="14" failures="0" errors="1" time="66.083">
+    <testsuite name="" tests="14" failures="0" errors="1" time="66.083">
+        <testsuite failures="1" time="0.068" errors="2" skipped="4" tests="8" name="com.google.errorprone.matchers.ConstructorOfClassTest">
+            <properties>
+                <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+                <property name="sun.cpu.isalist" value=""/>
+            </properties>
+            <testcase time="0.017" classname="com.google.errorprone.matchers.ConstructorOfClassTest" name="shouldMatchSingleConstructor"/>
+        </testsuite>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
Since the stack trace parser is not fully functional to parse stack trace from
different languages, adding a new content field to return the original stack
trace message for failed or error test case.

In addition, this change also tights up the JUnit XML schema check according to:
  - JUnit XML Schema - Windy Road
    https://windyroad.com.au/dl/Open%20Source/JUnit.xsd
  - junit-4.xsd - Revision 41192 - Jenkins