### PR TITLE
Parse stack traces with artifact ids instead of class names

### DIFF
--- a/src/main/java/com/google/testing/results/AntXmlParser.java
+++ b/src/main/java/com/google/testing/results/AntXmlParser.java
@@ -356,7 +356,7 @@ public class AntXmlParser {
 
       String fileAndLine = line.substring(openParen + 1, closeParen);
       int colon = fileAndLine.indexOf(':');
-      if (colon <= 0) {
+      if (colon <= 0 || colon != fileAndLine.lastIndexOf(':')) {
         textBuilder.append(line).append("\n");
         return;
       }
@@ -375,7 +375,13 @@ public class AntXmlParser {
         path = filename;
       }
 
-      int lineNumber = Integer.parseInt(fileAndLine.substring(colon + 1));
+      int lineNumber;
+      try {
+        lineNumber = Integer.parseInt(fileAndLine.substring(colon + 1));
+      } catch (NumberFormatException e) {
+        textBuilder.append(line).append("\n");
+        return;
+      }
 
       textBuilder.append(line.substring(0, openParen + 1));
       if (textBuilder.length() > 0) {

--- a/src/test/java/com/google/testing/results/AntXmlParserTest.java
+++ b/src/test/java/com/google/testing/results/AntXmlParserTest.java
@@ -43,7 +43,9 @@ import java.util.List;
  */
 @RunWith(JUnit4.class)
 public class AntXmlParserTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
   AntXmlParser parser;
 
   @Before
@@ -587,6 +589,45 @@ public class AntXmlParserTest {
                     .setStatus(TestStatus.FAILED)
                     .setClassName("com.google.example.SomeTest")
                     .addFailure(expectedFailure)
+                    .setName("testCase"))
+            .build();
+    assertThat(actual.get(0)).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldNotCrashWithMavenArtifactInsteadOfClassName() throws Exception {
+    List<TestSuite> actual =
+        parser.parse(getClass().getResourceAsStream("/stack-with-artifact-lines.xml"), UTF_8);
+    TestSuite expected =
+        TestSuite.newBuilder()
+            .setName("")
+            .setTotalCount(1)
+            .setFailureCount(1)
+            .setErrorCount(0)
+            .setSkippedCount(0)
+            .setElapsedTimeMillis(65)
+            .addTestCase(
+                TestCase.newBuilder()
+                    .setElapsedTimeMillis(0)
+                    .setStatus(TestStatus.FAILED)
+                    .setClassName("com.google.example.SomeTest")
+                    .addFailure(StackTrace.newBuilder()
+                        .setContent("Not true that <null> is equal to <\"null\">\n"
+                            + "\tat com.google.example.SomeTest.testCase(SomeTest.kt:33)\n"
+                            + "\tat a.b.c(com.example.app:example-auth@@13.0.1:55)\n"
+                            + "\tat u.v.w$a.a(com.google.android.gms:play-services-base@@17.5.0:47)\n")
+                        .addStackContent(
+                            text(
+                                "Not true that <null> is equal to <\"null\">\n"
+                                    + "\tat com.google.example.SomeTest.testCase("))
+                        .addStackContent(
+                            codeRef("SomeTest.kt:33", "com/google/example/SomeTest.kt", 33))
+                        .addStackContent(text(
+                            ")\n"
+                                + "\tat a.b.c(com.example.app:example-auth@@13.0.1:55)\n"
+                                + "\tat u.v.w$a.a(com.google.android.gms:play-services-base@@17.5.0:47)\n"
+                        ))
+                        .build())
                     .setName("testCase"))
             .build();
     assertThat(actual.get(0)).isEqualTo(expected);

--- a/src/test/resources/stack-with-artifact-lines.xml
+++ b/src/test/resources/stack-with-artifact-lines.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="" tests="1" failures="1" errors="0" skipped="0" time="0.065" timestamp="2018-03-02T11:29:30" hostname="localhost">
+  <properties />
+  <testcase name="testCase" classname="com.google.example.SomeTest" time="0.0">
+    <failure>Not true that &lt;null&gt; is equal to &lt;"null"&gt;
+	at com.google.example.SomeTest.testCase(SomeTest.kt:33)
+	at a.b.c(com.example.app:example-auth@@13.0.1:55)
+	at u.v.w$a.a(com.google.android.gms:play-services-base@@17.5.0:47)
+</failure>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
An Android stack trace might encode Maven artifact information into what
should be the class name and line number. Parsing such a line crashes the
parser. E.g.

```
  at a.b.c(com.google.example:example-library@@1.2.3:55
```

This CL adds safe guards against such stack traces. A future improvement
could enhance the parser to build coderefs out of this type of
information.